### PR TITLE
ItemEntity.class Mapped

### DIFF
--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -17,7 +17,9 @@ CLASS net/minecraft/class_57 net/minecraft/entity/Entity
 	FIELD field_1610 boundingBox Lnet/minecraft/class_25;
 	FIELD field_1614 air I
 	FIELD field_1615 fireImmune Z
+	FIELD field_1616 dataTracker Lnet/minecraft/class_216;
 	FIELD field_1630 dead Z
+	FIELD field_1631 eyeHeight F
 	FIELD field_1632 spacingXZ F
 	FIELD field_1633 spacingY F
 	FIELD field_1644 random Ljava/util/Random;
@@ -27,6 +29,7 @@ CLASS net/minecraft/class_57 net/minecraft/entity/Entity
 	FIELD field_1653 capeUrl Ljava/lang/String;
 	METHOD <init> (Lnet/minecraft/class_18;)V
 		ARG 1 world
+	METHOD method_1310 initDataTracker ()V
 	METHOD method_1316 updateCapeUrl ()V
 	METHOD method_1317 baseTick ()V
 	METHOD method_1318 isAlive ()Z
@@ -38,8 +41,13 @@ CLASS net/minecraft/class_57 net/minecraft/entity/Entity
 		ARG 1 nbt
 	METHOD method_1348 read (Lnet/minecraft/class_8;)V
 		ARG 1 nbt
+	METHOD method_1354 onPlayerInteraction (Lnet/minecraft/class_54;)V
+		ARG 1 player
 	METHOD method_1355 damage (Lnet/minecraft/class_57;I)Z
-	METHOD method_1363 readtNbt (Lnet/minecraft/class_8;)V
+		ARG 1 damageSource
+		ARG 2 amount
+	METHOD method_1358 bypassesSteppingEffects ()Z
+	METHOD method_1363 readNbt (Lnet/minecraft/class_8;)V
 		ARG 1 nbt
 	METHOD method_1368 writeNbt (Lnet/minecraft/class_8;)V
 		ARG 1 nbt
@@ -48,4 +56,11 @@ CLASS net/minecraft/class_57 net/minecraft/entity/Entity
 		ARG 1 dx
 		ARG 3 dy
 		ARG 5 dz
+	METHOD method_1372 pushOutOfBlock (DDD)Z
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
 	METHOD method_1386 markDead ()V
+	METHOD method_1392 damage (I)V
+		ARG 1 amount
+	METHOD method_1393 isSubmergedInWater ()Z

--- a/mappings/net/minecraft/entity/ItemEntity.mapping
+++ b/mappings/net/minecraft/entity/ItemEntity.mapping
@@ -1,1 +1,13 @@
 CLASS net/minecraft/class_142 net/minecraft/entity/ItemEntity
+	FIELD field_564 stack Lnet/minecraft/class_31;
+	FIELD field_565 itemAge I
+	FIELD field_566 pickupDelay I
+	FIELD field_567 initialRotationAngle F
+	FIELD field_568 itemTicks I
+	FIELD field_569 health I
+	METHOD <init> (Lnet/minecraft/class_18;DDDLnet/minecraft/class_31;)V
+		ARG 1 world
+		ARG 2 x
+		ARG 4 y
+		ARG 6 z
+		ARG 8 stack

--- a/mappings/net/minecraft/entity/data/DataTracker.mapping
+++ b/mappings/net/minecraft/entity/data/DataTracker.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_216 net/minecraft/entity/data/DataTracker

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -37,6 +37,7 @@ CLASS net/minecraft/class_18 net/minecraft/world/World
 	METHOD method_180 setState (Ljava/lang/String;Lnet/minecraft/class_58;)V
 		ARG 1 id
 		ARG 2 state
+	METHOD method_191 playSound (Lnet/minecraft/class_57;Ljava/lang/String;FF)V
 	METHOD method_200 (IIII)Z
 		ARG 1 x
 		ARG 2 y


### PR DESCRIPTION
The only nonstandard naming:

METHOD method_1372 pushOutOfBlock (DDD)Z
 - Checks if given location is inside of a block, and adjusts velocity accordingly, returns true if velocity was adjusted or more specifically if the entity is inside of a block. otherwise false.

--

There's more functionalities in later versions, but ultimately the name still matches, determines if block makes sound when stepped on by an entity, also determines if a block's onSteppedOn function is called by this entity:

METHOD method_1358 bypassesSteppingEffects ()Z

Very Similar to later versions but slightly different

--

Other names are pretty standard and stay closely to 1.20.2 existing names with VERY similar functionality


