### PR TITLE
Sound Mappings

### DIFF
--- a/mappings/net/minecraft/client/InteractionManager.mapping
+++ b/mappings/net/minecraft/client/InteractionManager.mapping
@@ -14,3 +14,4 @@ CLASS net/minecraft/class_504 net/minecraft/client/InteractionManager
 	METHOD method_1719 attackEntity (Lnet/minecraft/class_54;Lnet/minecraft/class_57;)V
 		ARG 1 player
 		ARG 2 target
+	METHOD method_1720 tick ()V

--- a/mappings/net/minecraft/client/sound/Sound.mapping
+++ b/mappings/net/minecraft/client/sound/Sound.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_267 net/minecraft/client/sound/Sound
+	FIELD field_2126 id Ljava/lang/String;
+	FIELD field_2127 soundFile Ljava/net/URL;
+	METHOD <init> (Ljava/lang/String;Ljava/net/URL;)V
+		ARG 1 id
+		ARG 2 soundFile

--- a/mappings/net/minecraft/client/sound/SoundEntry.mapping
+++ b/mappings/net/minecraft/client/sound/SoundEntry.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/class_266 net/minecraft/client/sound/SoundEntry
+	FIELD field_1086 loadedSoundCount I
+	FIELD field_1087 isRandom Z
+	FIELD field_1088 random Ljava/util/Random;
+	FIELD field_1089 weightedSoundSet Ljava/util/Map;
+	FIELD field_1090 loadedSounds Ljava/util/List;
+	METHOD method_957 getSounds ()Lnet/minecraft/class_267;
+	METHOD method_958 get (Ljava/lang/String;)Lnet/minecraft/class_267;
+		ARG 1 id
+	METHOD method_959 loadStatic (Ljava/lang/String;Ljava/io/File;)Lnet/minecraft/class_267;
+		ARG 1 soundName
+		ARG 2 soundFile

--- a/mappings/net/minecraft/client/sound/SoundManager.mapping
+++ b/mappings/net/minecraft/client/sound/SoundManager.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_617 net/minecraft/client/sound/SoundManager
 	FIELD field_2668 sounds Lnet/minecraft/class_266;
 	FIELD field_2669 streamingSounds Lnet/minecraft/class_266;
 	FIELD field_2670 music Lnet/minecraft/class_266;
+	FIELD field_2671 soundSourceSuffix I
 	FIELD field_2672 gameOptions Lnet/minecraft/class_322;
 	FIELD field_2673 started Z
 	FIELD field_2674 random Ljava/util/Random;

--- a/mappings/net/minecraft/client/sound/SoundManager.mapping
+++ b/mappings/net/minecraft/client/sound/SoundManager.mapping
@@ -1,5 +1,45 @@
 CLASS net/minecraft/class_617 net/minecraft/client/sound/SoundManager
 	FIELD field_2667 soundSystem Lpaulscode/sound/SoundSystem;
+	FIELD field_2668 sounds Lnet/minecraft/class_266;
+	FIELD field_2669 streamingSounds Lnet/minecraft/class_266;
+	FIELD field_2670 music Lnet/minecraft/class_266;
+	FIELD field_2672 gameOptions Lnet/minecraft/class_322;
+	FIELD field_2673 started Z
+	FIELD field_2674 random Ljava/util/Random;
+	FIELD field_2675 timeUntilNextSong I
+	METHOD method_2008 updateMusicVolume ()V
+	METHOD method_2009 playSound (Ljava/lang/String;FF)V
+		ARG 1 id
+		ARG 2 volume
+		ARG 3 pitch
+	METHOD method_2010 playStreaming (Ljava/lang/String;FFFFF)V
+		ARG 1 id
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+		ARG 5 volume
+		ARG 6 pitch
 	METHOD method_2011 loadSound (Ljava/lang/String;Ljava/io/File;)V
+		ARG 1 id
+		ARG 2 soundFile
+	METHOD method_2012 loadSounds (Lnet/minecraft/class_322;)V
+		ARG 1 gameOptions
+	METHOD method_2013 updateListenerPosition (Lnet/minecraft/class_127;F)V
+		ARG 1 player
+		ARG 2 scale
+	METHOD method_2014 stop ()V
+	METHOD method_2015 playSound (Ljava/lang/String;FFFFF)V
+		ARG 1 id
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+		ARG 5 volume
+		ARG 6 pitch
 	METHOD method_2016 loadStreaming (Ljava/lang/String;Ljava/io/File;)V
+		ARG 1 id
+		ARG 2 soundFile
+	METHOD method_2017 tick ()V
 	METHOD method_2018 loadMusic (Ljava/lang/String;Ljava/io/File;)V
+		ARG 1 id
+		ARG 2 soundFile
+	METHOD method_2019 start ()V

--- a/mappings/paulscode/sound/libraries/LibraryLWJGLOpenAL.mapping
+++ b/mappings/paulscode/sound/libraries/LibraryLWJGLOpenAL.mapping
@@ -1,1 +1,0 @@
-CLASS paulscode/sound/libraries/LibraryLWJGLOpenAL

--- a/mappings/paulscode/sound/libraries/LibraryLWJGLOpenAL.mapping
+++ b/mappings/paulscode/sound/libraries/LibraryLWJGLOpenAL.mapping
@@ -1,0 +1,1 @@
+CLASS paulscode/sound/libraries/LibraryLWJGLOpenAL


### PR DESCRIPTION
Maps `SoundManager`, `SoundEntry` and `Sound` fully, along with `tick` in `InteractionManager`.

This was a pain in cause in modern, these three classes are instead like 20+ different classes with wildly different code. I've had to deviate in naming in the play and load sound methods due to this.