### PR TITLE
Mappings for items

### DIFF
--- a/mappings/net/minecraft/item/BucketItem.mapping
+++ b/mappings/net/minecraft/item/BucketItem.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_220 net/minecraft/item/BucketItem
+	FIELD field_842 fluid I
 	METHOD <init> (II)V
 		ARG 1 id
+		ARG 2 fluid

--- a/mappings/net/minecraft/item/BucketItem.mapping
+++ b/mappings/net/minecraft/item/BucketItem.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_220 net/minecraft/item/BucketItem
-	FIELD field_842 fluid I
+	FIELD field_842 fluidBlockId I
 	METHOD <init> (II)V
 		ARG 1 id
-		ARG 2 fluid
+		ARG 2 fluidBlockId

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -149,7 +149,7 @@ CLASS net/minecraft/class_124 net/minecraft/item/Item
 	METHOD method_447 getAttackDamage (Lnet/minecraft/class_57;)I
 		ARG 1 attackedEntity
 	METHOD method_448 isHandheld ()Z
-	METHOD method_449 isHandheldFishingRod ()Z
+	METHOD method_449 isHandheldRod ()Z
 		COMMENT Determines if an item should be rotated like a fishing rod when held in hand
 	METHOD method_450 isSuitableFor (Lnet/minecraft/class_17;)Z
 		ARG 1 block
@@ -193,5 +193,5 @@ CLASS net/minecraft/class_124 net/minecraft/item/Item
 	METHOD method_467 getCraftingReturnItem ()Lnet/minecraft/class_124;
 	METHOD method_468 hasCraftingReturnItem ()Z
 	METHOD method_469 getTranslatedName ()Ljava/lang/String;
-	METHOD method_470 getMetadata (I)I
+	METHOD method_470 getPlacementMetadata (I)I
 		ARG 1 meta

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -111,7 +111,7 @@ CLASS net/minecraft/class_124 net/minecraft/item/Item
 	FIELD field_485 STONE_SWORD Lnet/minecraft/class_124;
 	FIELD field_486 STONE_SHOVEL Lnet/minecraft/class_124;
 	FIELD field_487 STONE_PICKAXE Lnet/minecraft/class_124;
-	FIELD field_488 STONE_HATCHET Lnet/minecraft/class_124;
+	FIELD field_488 STONE_AXE Lnet/minecraft/class_124;
 	FIELD field_489 DIAMOND_SWORD Lnet/minecraft/class_124;
 	FIELD field_490 DIAMOND_SHOVEL Lnet/minecraft/class_124;
 	FIELD field_491 DIAMOND_PICKAXE Lnet/minecraft/class_124;
@@ -149,6 +149,8 @@ CLASS net/minecraft/class_124 net/minecraft/item/Item
 	METHOD method_447 getAttackDamage (Lnet/minecraft/class_57;)I
 		ARG 1 attackedEntity
 	METHOD method_448 isHandheld ()Z
+	METHOD method_449 isHandheldFishingRod ()Z
+		COMMENT Determines if an item should be rotated like a fishing rod when held in hand
 	METHOD method_450 isSuitableFor (Lnet/minecraft/class_17;)Z
 		ARG 1 block
 	METHOD method_451 use (Lnet/minecraft/class_31;Lnet/minecraft/class_18;Lnet/minecraft/class_54;)Lnet/minecraft/class_31;
@@ -191,3 +193,5 @@ CLASS net/minecraft/class_124 net/minecraft/item/Item
 	METHOD method_467 getCraftingReturnItem ()Lnet/minecraft/class_124;
 	METHOD method_468 hasCraftingReturnItem ()Z
 	METHOD method_469 getTranslatedName ()Ljava/lang/String;
+	METHOD method_470 getMetadata (I)I
+		ARG 1 meta


### PR DESCRIPTION
Completed mappings for `BucketItem`, renamed `STONE_HATCHET` to `STONE_AXE` for consistency and a few other item-related mappings.