### PR TITLE
Mappings for foliage, grass, and water colors

### DIFF
--- a/mappings/net/minecraft/client/color/world/FoliageColors.mapping
+++ b/mappings/net/minecraft/client/color/world/FoliageColors.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_334 net/minecraft/client/color/world/FoliageColors
+	FIELD field_1243 colorMap [I
+	METHOD method_1079 getSpruceColor ()I
+	METHOD method_1080 getColor (DD)I
+		ARG 0 temperature
+		ARG 2 humidity
+	METHOD method_1081 setColorMap ([I)V
+		ARG 0 colorMap
+	METHOD method_1082 getBirchColor ()I
+	METHOD method_1083 getDefaultColor ()I

--- a/mappings/net/minecraft/client/color/world/GrassColors.mapping
+++ b/mappings/net/minecraft/client/color/world/GrassColors.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/class_287 net/minecraft/client/color/world/GrassColors
+	FIELD field_1141 colorMap [I
+	METHOD method_981 getColor (DD)I
+		ARG 0 temperature
+		ARG 2 humidity
+	METHOD method_982 setColorMap ([I)V
+		ARG 0 colorMap

--- a/mappings/net/minecraft/client/color/world/WaterColors.mapping
+++ b/mappings/net/minecraft/client/color/world/WaterColors.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_279 net/minecraft/client/color/world/WaterColors
+	FIELD field_1129 colorMap [I
+	METHOD method_972 setColorMap ([I)V
+		ARG 0 colorMap

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -129,6 +129,8 @@ CLASS net/minecraft/class_124 net/minecraft/item/Item
 		ARG 2 block
 	METHOD method_439 getTextureId (Lnet/minecraft/class_31;)I
 		ARG 1 itemStack
+	METHOD method_440 getColorMultiplier (I)I
+		ARG 1 color
 	METHOD method_441 getTextureId (I)I
 		ARG 1 damage
 	METHOD method_442 getTranslationKey (Lnet/minecraft/class_31;)Ljava/lang/String;


### PR DESCRIPTION
Created `net.minecraft.client.color.world` package based on Yarn, which contains `FoliageColors`, `GrassColors`, and `WaterColors` (in Yarn this is `BiomeColors` but as it only handles the color of water in b1.7.3 I thought `WaterColors` was a more appropriate name).

Also used `temperature` and `humidity` for some parameters based on Yarn, did not see any existing mappings for these concepts so I went with what Yarn uses.