### PR TITLE
Mappings for blocks

### DIFF
--- a/mappings/net/minecraft/block/BedBlock.mapping
+++ b/mappings/net/minecraft/block/BedBlock.mapping
@@ -1,3 +1,13 @@
 CLASS net/minecraft/class_485 net/minecraft/block/BedBlock
 	METHOD <init> (I)V
 		ARG 1 id
+	METHOD method_1657 (Lnet/minecraft/class_18;IIIZ)V
+		ARG 0 world
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+	METHOD method_1661 (Lnet/minecraft/class_18;IIII)Lnet/minecraft/class_63;
+		ARG 0 world
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -367,6 +367,9 @@ CLASS net/minecraft/class_17 net/minecraft/block/Block
 		ARG 4 z
 	METHOD method_1625 dropStacks (Lnet/minecraft/class_18;IIIIF)V
 		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
 	METHOD method_1626 getTextureId (Lnet/minecraft/class_14;IIII)I
 		ARG 1 blockView
 		ARG 2 x

--- a/mappings/net/minecraft/block/ButtonBlock.mapping
+++ b/mappings/net/minecraft/block/ButtonBlock.mapping
@@ -1,1 +1,14 @@
 CLASS net/minecraft/class_323 net/minecraft/block/ButtonBlock
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 textureId
+	METHOD method_1047 (Lnet/minecraft/class_18;III)I
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1048 breakIfCannotPlaceAt (Lnet/minecraft/class_18;III)Z
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/CactusBlock.mapping
+++ b/mappings/net/minecraft/block/CactusBlock.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_329 net/minecraft/block/CactusBlock
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 textureId

--- a/mappings/net/minecraft/block/CakeBlock.mapping
+++ b/mappings/net/minecraft/block/CakeBlock.mapping
@@ -2,3 +2,9 @@ CLASS net/minecraft/class_463 net/minecraft/block/CakeBlock
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 textureId
+	METHOD method_1528 tryEat (Lnet/minecraft/class_18;IIILnet/minecraft/class_54;)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+		ARG 5 player

--- a/mappings/net/minecraft/block/ChestBlock.mapping
+++ b/mappings/net/minecraft/block/ChestBlock.mapping
@@ -2,3 +2,8 @@ CLASS net/minecraft/class_110 net/minecraft/block/ChestBlock
 	FIELD field_337 random Ljava/util/Random;
 	METHOD <init> (I)V
 		ARG 1 id
+	METHOD method_409 (Lnet/minecraft/class_18;III)Z
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/CropBlock.mapping
+++ b/mappings/net/minecraft/block/CropBlock.mapping
@@ -1,1 +1,11 @@
 CLASS net/minecraft/class_301 net/minecraft/block/CropBlock
+	METHOD method_996 applyFullGrowth (Lnet/minecraft/class_18;III)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_997 getAvailableMoisture (Lnet/minecraft/class_18;III)F
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/DetectorRailBlock.mapping
+++ b/mappings/net/minecraft/block/DetectorRailBlock.mapping
@@ -1,1 +1,9 @@
 CLASS net/minecraft/class_342 net/minecraft/block/DetectorRailBlock
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 textureId
+	METHOD method_1144 (Lnet/minecraft/class_18;IIII)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/DispenserBlock.mapping
+++ b/mappings/net/minecraft/block/DispenserBlock.mapping
@@ -1,3 +1,15 @@
 CLASS net/minecraft/class_526 net/minecraft/block/DispenserBlock
+	FIELD field_2206 random Ljava/util/Random;
 	METHOD <init> (I)V
 		ARG 1 id
+	METHOD method_1774 dispense (Lnet/minecraft/class_18;IIILjava/util/Random;)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+		ARG 5 random
+	METHOD method_1775 updateDirection (Lnet/minecraft/class_18;III)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/DoorBlock.mapping
+++ b/mappings/net/minecraft/block/DoorBlock.mapping
@@ -1,1 +1,8 @@
 CLASS net/minecraft/class_252 net/minecraft/block/DoorBlock
+	METHOD method_837 (Lnet/minecraft/class_18;IIIZ)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_839 (I)I
+		ARG 1 meta

--- a/mappings/net/minecraft/block/FarmlandBlock.mapping
+++ b/mappings/net/minecraft/block/FarmlandBlock.mapping
@@ -1,3 +1,13 @@
 CLASS net/minecraft/class_492 net/minecraft/block/FarmlandBlock
 	METHOD <init> (I)V
 		ARG 1 id
+	METHOD method_1672 hasCrop (Lnet/minecraft/class_18;III)Z
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1673 isWaterNearby (Lnet/minecraft/class_18;III)Z
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/FenceBlock.mapping
+++ b/mappings/net/minecraft/block/FenceBlock.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_229 net/minecraft/block/FenceBlock
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 textureId

--- a/mappings/net/minecraft/block/FireBlock.mapping
+++ b/mappings/net/minecraft/block/FireBlock.mapping
@@ -1,4 +1,38 @@
 CLASS net/minecraft/class_474 net/minecraft/block/FireBlock
+	FIELD field_2307 burnChances [I
+	FIELD field_2308 spreadChances [I
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 textureId
+	METHOD method_1822 registerFlammableBlock (III)V
+		ARG 1 block
+		ARG 2 burnChance
+		ARG 3 spreadChance
+	METHOD method_1823 trySpreadingFire (Lnet/minecraft/class_18;IIIILjava/util/Random;I)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+		ARG 5 spreadFactor
+		ARG 6 random
+		ARG 7 currentAge
+	METHOD method_1824 isBlockFlammable (Lnet/minecraft/class_14;III)Z
+		ARG 1 blockView
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1825 (Lnet/minecraft/class_18;IIII)I
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1826 areBlocksAroundFlammable (Lnet/minecraft/class_18;III)Z
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1827 (Lnet/minecraft/class_18;III)I
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/FurnaceBlock.mapping
+++ b/mappings/net/minecraft/block/FurnaceBlock.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_421 net/minecraft/block/FurnaceBlock
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z
-	METHOD method_1404 (Lnet/minecraft/class_18;III)V
+	METHOD method_1404 updateDirection (Lnet/minecraft/class_18;III)V
 		ARG 1 world
 		ARG 2 x
 		ARG 3 y

--- a/mappings/net/minecraft/block/IceBlock.mapping
+++ b/mappings/net/minecraft/block/IceBlock.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_302 net/minecraft/block/IceBlock
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 textureId

--- a/mappings/net/minecraft/block/JukeboxBlock.mapping
+++ b/mappings/net/minecraft/block/JukeboxBlock.mapping
@@ -1,1 +1,15 @@
 CLASS net/minecraft/class_88 net/minecraft/block/JukeboxBlock
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 textureId
+	METHOD method_348 tryEjectRecord (Lnet/minecraft/class_18;III)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_349 insertRecord (Lnet/minecraft/class_18;IIII)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+		ARG 5 id

--- a/mappings/net/minecraft/block/LeavesBlock.mapping
+++ b/mappings/net/minecraft/block/LeavesBlock.mapping
@@ -2,3 +2,8 @@ CLASS net/minecraft/class_299 net/minecraft/block/LeavesBlock
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 textureId
+	METHOD method_990 (Lnet/minecraft/class_18;III)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/LeverBlock.mapping
+++ b/mappings/net/minecraft/block/LeverBlock.mapping
@@ -2,3 +2,8 @@ CLASS net/minecraft/class_530 net/minecraft/block/LeverBlock
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 textureId
+	METHOD method_1785 breakIfCannotPlaceAt (Lnet/minecraft/class_18;III)Z
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/NetherPortalBlock.mapping
+++ b/mappings/net/minecraft/block/NetherPortalBlock.mapping
@@ -2,3 +2,8 @@ CLASS net/minecraft/class_207 net/minecraft/block/NetherPortalBlock
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 textureId
+	METHOD method_736 (Lnet/minecraft/class_18;III)Z
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/PlantBlock.mapping
+++ b/mappings/net/minecraft/block/PlantBlock.mapping
@@ -2,5 +2,10 @@ CLASS net/minecraft/class_473 net/minecraft/block/PlantBlock
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 textureId
-	METHOD method_1684 (Lnet/minecraft/class_18;III)V
+	METHOD method_1683 canPlantOnTop (I)Z
+		ARG 1 id
+	METHOD method_1684 breakIfCannotGrow (Lnet/minecraft/class_18;III)V
 		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/PressurePlateBlock.mapping
+++ b/mappings/net/minecraft/block/PressurePlateBlock.mapping
@@ -3,3 +3,8 @@ CLASS net/minecraft/class_457 net/minecraft/block/PressurePlateBlock
 		ARG 1 id
 		ARG 2 textureId
 		ARG 4 material
+	METHOD method_1512 (Lnet/minecraft/class_18;III)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/RedstoneOreBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneOreBlock.mapping
@@ -4,3 +4,13 @@ CLASS net/minecraft/class_396 net/minecraft/block/RedstoneOreBlock
 		ARG 1 id
 		ARG 2 textureId
 		ARG 3 lit
+	METHOD method_1252 light (Lnet/minecraft/class_18;III)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1253 spawnParticles (Lnet/minecraft/class_18;III)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/RedstoneWireBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneWireBlock.mapping
@@ -3,3 +3,28 @@ CLASS net/minecraft/class_408 net/minecraft/block/RedstoneWireBlock
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 textureId
+	METHOD method_1286 (Lnet/minecraft/class_18;IIIIII)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1287 (Lnet/minecraft/class_14;IIII)Z
+		ARG 0 blockView
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+	METHOD method_1288 (Lnet/minecraft/class_18;IIII)I
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1289 (Lnet/minecraft/class_18;III)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1290 (Lnet/minecraft/class_18;III)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/RepeaterBlock.mapping
+++ b/mappings/net/minecraft/block/RepeaterBlock.mapping
@@ -3,3 +3,8 @@ CLASS net/minecraft/class_510 net/minecraft/block/RepeaterBlock
 	METHOD <init> (IZ)V
 		ARG 1 id
 		ARG 2 lit
+	METHOD method_1728 (Lnet/minecraft/class_18;IIII)Z
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/SandBlock.mapping
+++ b/mappings/net/minecraft/block/SandBlock.mapping
@@ -2,3 +2,13 @@ CLASS net/minecraft/class_123 net/minecraft/block/SandBlock
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 textureId
+	METHOD method_435 (Lnet/minecraft/class_18;III)Z
+		ARG 0 world
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+	METHOD method_436 (Lnet/minecraft/class_18;III)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/SaplingBlock.mapping
+++ b/mappings/net/minecraft/block/SaplingBlock.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_154 net/minecraft/block/SaplingBlock
-	METHOD method_533 (Lnet/minecraft/class_18;IIILjava/util/Random;)V
+	METHOD method_533 generate (Lnet/minecraft/class_18;IIILjava/util/Random;)V
 		ARG 1 world
 		ARG 2 x
 		ARG 3 y

--- a/mappings/net/minecraft/block/SlabBlock.mapping
+++ b/mappings/net/minecraft/block/SlabBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_553 net/minecraft/block/SlabBlock
+	FIELD field_2323 names [Ljava/lang/String;
 	FIELD field_2324 doubleSlab Z
 	METHOD <init> (IZ)V
 		ARG 1 id

--- a/mappings/net/minecraft/block/SnowBlock.mapping
+++ b/mappings/net/minecraft/block/SnowBlock.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_606 net/minecraft/block/SnowBlock
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 textureId

--- a/mappings/net/minecraft/block/SnowyBlock.mapping
+++ b/mappings/net/minecraft/block/SnowyBlock.mapping
@@ -1,1 +1,9 @@
 CLASS net/minecraft/class_224 net/minecraft/block/SnowyBlock
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 textureId
+	METHOD method_768 breakIfCannotPlaceAt (Lnet/minecraft/class_18;III)Z
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/StairsBlock.mapping
+++ b/mappings/net/minecraft/block/StairsBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_416 net/minecraft/block/StairsBlock
+	FIELD field_1672 baseBlock Lnet/minecraft/class_17;
 	METHOD <init> (ILnet/minecraft/class_17;)V
 		ARG 1 id
 		ARG 2 block

--- a/mappings/net/minecraft/block/SugarCaneBlock.mapping
+++ b/mappings/net/minecraft/block/SugarCaneBlock.mapping
@@ -1,1 +1,9 @@
 CLASS net/minecraft/class_376 net/minecraft/block/SugarCaneBlock
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 textureId
+	METHOD method_1208 breakIfCannotGrow (Lnet/minecraft/class_18;III)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/TorchBlock.mapping
+++ b/mappings/net/minecraft/block/TorchBlock.mapping
@@ -2,3 +2,13 @@ CLASS net/minecraft/class_494 net/minecraft/block/TorchBlock
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 textureId
+	METHOD method_1674 canPlaceOn (Lnet/minecraft/class_18;III)Z
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1675 breakIfCannotPlaceAt (Lnet/minecraft/class_18;III)Z
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/block/TrapdoorBlock.mapping
+++ b/mappings/net/minecraft/block/TrapdoorBlock.mapping
@@ -1,1 +1,8 @@
 CLASS net/minecraft/class_328 net/minecraft/block/TrapdoorBlock
+	METHOD method_1059 (Lnet/minecraft/class_18;IIIZ)V
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1060 (I)V
+		ARG 1 meta


### PR DESCRIPTION
Mappings for `id` and `textureId` arguments in block constructors, as well as `world`, `x`, `y`, and `z` in many block methods.

Also includes mappings for some block methods. Method names were based off of Yarn equivalents where possible.