### PR TITLE
Mouse and ScreenScaler mappings

### DIFF
--- a/mappings/net/minecraft/client/Mouse.mapping
+++ b/mappings/net/minecraft/client/Mouse.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/class_596 net/minecraft/client/Mouse
+	FIELD field_2586 deltaX I
+	FIELD field_2587 deltaY I
+	FIELD field_2588 parent Ljava/awt/Component;
+	FIELD field_2589 cursor Lorg/lwjgl/input/Cursor;
+	FIELD field_2590 unused I
+	METHOD <init> (Ljava/awt/Component;)V
+		ARG 1 parent
+	METHOD method_1970 lockCursor ()V
+	METHOD method_1971 unlockCursor ()V
+	METHOD method_1972 poll ()V

--- a/mappings/net/minecraft/client/util/ScreenScaler.mapping
+++ b/mappings/net/minecraft/client/util/ScreenScaler.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/class_564 net/minecraft/client/util/ScreenScaler
+	FIELD field_2389 rawScaledWidth D
+		COMMENT scaledWidth before rounding to whole numbers
+	FIELD field_2390 rawScaledHeight D
+		COMMENT scaledHeight before rounding to whole numbers
+	FIELD field_2391 scaleFactor I
+	FIELD field_2392 scaledWidth I
+	FIELD field_2393 scaledHeight I
+	METHOD <init> (Lnet/minecraft/class_322;II)V
+		ARG 1 options
+		ARG 2 framebufferWidth
+		ARG 3 framebufferHeight
+	METHOD method_1857 getScaledWidth ()I
+	METHOD method_1858 getScaledHeight ()I


### PR DESCRIPTION
The methods in ScreenScaler do technically somewhat live in net/minecraft/client/util/Window, but I think it wouldnt be reasonable to call ScreenScaler Window, ScaledResolution could be another name for it