### PR TITLE
Map PlayerInventory

### DIFF
--- a/mappings/net/minecraft/entity/player/PlayerInventory.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerInventory.mapping
@@ -7,7 +7,45 @@ CLASS net/minecraft/class_136 net/minecraft/entity/player/PlayerInventory
 	FIELD field_750 cursorStack Lnet/minecraft/class_31;
 	METHOD <init> (Lnet/minecraft/class_54;)V
 		ARG 1 player
+	METHOD method_671 addStack (Lnet/minecraft/class_31;)Z
+		ARG 1 stack
+	METHOD method_672 getAttackDamage (Lnet/minecraft/class_57;)I
+		ARG 1 entity
+	METHOD method_673 writeNbt (Lnet/minecraft/class_202;)Lnet/minecraft/class_202;
+		ARG 1 nbt
+	METHOD method_674 getStrengthOnBlock (Lnet/minecraft/class_17;)F
+		ARG 1 block
 	METHOD method_675 getSelectedItem ()Lnet/minecraft/class_31;
+	METHOD method_676 remove (I)Z
+		ARG 1 itemId
 	METHOD method_677 setCursorStack (Lnet/minecraft/class_31;)V
 		ARG 1 cursorStack
+	METHOD method_678 readNbt (Lnet/minecraft/class_202;)V
+		ARG 1 nbt
+	METHOD method_679 isUsingEffectiveTool (Lnet/minecraft/class_17;)Z
+		ARG 1 block
+	METHOD method_680 damageArmor (I)V
+		ARG 1 amount
+	METHOD method_681 contains (Lnet/minecraft/class_31;)Z
+		ARG 1 stack
+	METHOD method_682 indexOf (I)I
+		ARG 1 itemId
+	METHOD method_683 indexOf (Lnet/minecraft/class_31;)I
+		ARG 1 stack
+	METHOD method_684 getHotbarSize ()I
+	METHOD method_685 combineStacks (Lnet/minecraft/class_31;)I
+		COMMENT combines existing stacks that are of the same itemId
+		COMMENT @return remaining count of the item
+		ARG 1 stack
+	METHOD method_686 inventoryTick ()V
+	METHOD method_687 getTotalArmorDurability ()I
+	METHOD method_688 dropInventory ()V
 	METHOD method_689 getCursorStack ()Lnet/minecraft/class_31;
+	METHOD method_690 getEmptySlot ()I
+	METHOD method_691 setHeldItem (IZ)V
+		COMMENT Will replace currently held item, removing it
+		ARG 1 itemId
+	METHOD method_692 scrollInHotbar (I)V
+		ARG 1 direction
+	METHOD method_693 getArmorStack (I)Lnet/minecraft/class_31;
+		ARG 1 index


### PR DESCRIPTION
All of my yarny deduction were grabbed from here
https://maven.fabricmc.net/docs/yarn-1.21+build.6/net/minecraft/entity/player/PlayerInventory.html
The exceptions to yarn-exact naming is the armor amount read for the hud, where the functionality is slightly different where I chose to name it
`getTotalArmorDurability`
The speed to breaking blocks
`getStrengthOnBlock`
The attack amount was based off entity code in modern yarn
`getAttackDamage`
If the correct tool is being used
`isUsingEffectiveTool`
and maybe some other stuff, feel free to take a close look, it is a short addition

Everything else falls in line