### PR TITLE
Minor Fixes, setPos -> setPosition, handWingProgress -> handSwingProgress

### DIFF
--- a/mappings/net/minecraft/client/render/entity/model/EntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EntityModel.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_173 net/minecraft/client/render/entity/model/EntityModel
-	FIELD field_1427 handWingProgress F
+	FIELD field_1427 handSwingProgress F
 	FIELD field_1428 riding Z
 	METHOD method_1209 animateModel (Lnet/minecraft/class_127;FFF)V
 		ARG 1 entity

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -143,7 +143,7 @@ CLASS net/minecraft/class_57 net/minecraft/entity/Entity
 		COMMENT
 		ARG 1 id
 		ARG 2 amount
-	METHOD method_1340 setPos (DDD)V
+	METHOD method_1340 setPosition (DDD)V
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z


### PR DESCRIPTION
Entity's `setPos` should be `setPosition`
see https://maven.fabricmc.net/docs/yarn-1.21+build.6/net/minecraft/entity/Entity.html#setPosition(double,double,double)
EntityModel's `handWingProgress` should be `handSwingProgress`
see https://maven.fabricmc.net/docs/yarn-1.21+build.6/net/minecraft/client/render/entity/model/EntityModel.html#handSwingProgress