### PR TITLE
Fix Javadoc Issues

### DIFF
--- a/mappings/net/minecraft/screen/PlayerScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/PlayerScreenHandler.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_277 net/minecraft/screen/PlayerScreenHandler
 	FIELD field_1125 craftingResult Lnet/minecraft/class_134;
 	FIELD field_1126 isLocal Z
 		COMMENT Determines if the world is local
-		COMMENT Will be true on Client in Singleplayer & on Server in Multiplayer
+		COMMENT Will be true on Client in Singleplayer and on Server in Multiplayer
 	METHOD <init> (Lnet/minecraft/class_136;)V
 		ARG 1 inventory
 	METHOD <init> (Lnet/minecraft/class_136;Z)V

--- a/mappings/net/minecraft/screen/ScreenHandlerListener.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandlerListener.mapping
@@ -3,9 +3,9 @@ CLASS net/minecraft/class_633 net/minecraft/screen/ScreenHandlerListener
 		COMMENT Passes integers from Server Screen Handler to Client Screen Handler so that animations can be visible, e.g. Smelting Progress, Fuel left for rendering
 		ARG 1 handler
 		ARG 2 syncId
-			COMMENT Arbitrary integer specific to this screenHandler, used as an identifier for a specific property. Set this to any int, as long as it is consistent. Normally starts at 0 going up.
+			COMMENT is an arbitrary integer specific to this screenHandler, used as an identifier for a specific property. Set this to any int, as long as it is consistent. Normally starts at 0 going up
 		ARG 3 trackedValue
-			COMMENT This integer is synced to the client.
+			COMMENT is an integer that is synced to the client
 	METHOD method_2100 onSlotUpdate (Lnet/minecraft/class_71;ILnet/minecraft/class_31;)V
 		COMMENT Update a ScreenHandler's slot with a different item stack
 		ARG 1 handler


### PR DESCRIPTION
Fixes these warnings/errors in javadoc lint process

```
 net\minecraft\screen\PlayerScreenHandler.java:40: error: bad HTML entity
   * Will be true on Client in Singleplayer & on Server in Multiplayer
                                            ^
```
```
 Task :javadocLint FAILED
lint: net/minecraft/screen/ScreenHandlerListener.onPropertyUpdate(Lnet/minecraft/class_71;II)V.syncId: parameter javadoc ends with '.'
lint: net/minecraft/screen/ScreenHandlerListener.onPropertyUpdate(Lnet/minecraft/class_71;II)V.syncId: parameter javadoc starts with uppercase word 'Arbitrary'
lint: net/minecraft/screen/ScreenHandlerListener.onPropertyUpdate(Lnet/minecraft/class_71;II)V.trackedValue: parameter javadoc ends with '.'
lint: net/minecraft/screen/ScreenHandlerListener.onPropertyUpdate(Lnet/minecraft/class_71;II)V.trackedValue: parameter javadoc starts with uppercase word 'This'
```