### PR TITLE
Map ServerPlayerInteractionManager

### DIFF
--- a/mappings/net/minecraft/entity/player/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/ServerPlayerEntity.mapping
@@ -1,9 +1,12 @@
 CLASS net/minecraft/class_69 net/minecraft/entity/player/ServerPlayerEntity
+	FIELD field_255 networkHandler Lnet/minecraft/class_11;
 	FIELD field_256 server Lnet/minecraft/server/MinecraftServer;
+	FIELD field_261 interactionManager Lnet/minecraft/class_70;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_18;Ljava/lang/String;Lnet/minecraft/class_70;)V
 		ARG 1 server
 		ARG 2 world
 		ARG 3 name
+		ARG 4 interactionManager
 	METHOD method_310 (FFZZFF)V
 		ARG 3 jumping
 		ARG 5 pitch

--- a/mappings/net/minecraft/server/network/ServerPlayerInteractionManager.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerInteractionManager.mapping
@@ -3,14 +3,14 @@ CLASS net/minecraft/class_70 net/minecraft/server/network/ServerPlayerInteractio
 	FIELD field_2310 world Lnet/minecraft/class_73;
 	FIELD field_2311 blockBreakProgress F
 	FIELD field_2312 failedMiningStartTime I
-	FIELD field_2313 failedMiningPosX I
-	FIELD field_2314 failedMiningPosY I
-	FIELD field_2315 failedMiningPosZ I
+	FIELD field_2313 failedMiningX I
+	FIELD field_2314 failedMiningY I
+	FIELD field_2315 failedMiningZ I
 	FIELD field_2316 tickCounter I
 	FIELD field_2317 mining Z
-	FIELD field_2318 miningPosX I
-	FIELD field_2319 miningPosY I
-	FIELD field_2320 miningPosZ I
+	FIELD field_2318 miningX I
+	FIELD field_2319 miningY I
+	FIELD field_2320 miningZ I
 	FIELD field_2321 startMiningTime I
 	METHOD <init> (Lnet/minecraft/class_73;)V
 		ARG 1 world
@@ -24,7 +24,7 @@ CLASS net/minecraft/class_70 net/minecraft/server/network/ServerPlayerInteractio
 		ARG 2 y
 		ARG 3 z
 		ARG 4 direction
-	METHOD method_1831 iteractItem (Lnet/minecraft/class_54;Lnet/minecraft/class_18;Lnet/minecraft/class_31;)Z
+	METHOD method_1831 interactItem (Lnet/minecraft/class_54;Lnet/minecraft/class_18;Lnet/minecraft/class_31;)Z
 		ARG 1 player
 		ARG 2 world
 		ARG 3 stack

--- a/mappings/net/minecraft/server/network/ServerPlayerInteractionManager.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerInteractionManager.mapping
@@ -1,0 +1,48 @@
+CLASS net/minecraft/class_70 net/minecraft/server/network/ServerPlayerInteractionManager
+	FIELD field_2309 player Lnet/minecraft/class_54;
+	FIELD field_2310 world Lnet/minecraft/class_73;
+	FIELD field_2311 blockBreakProgress F
+	FIELD field_2312 failedMiningStartTime I
+	FIELD field_2313 failedMiningPosX I
+	FIELD field_2314 failedMiningPosY I
+	FIELD field_2315 failedMiningPosZ I
+	FIELD field_2316 tickCounter I
+	FIELD field_2317 mining Z
+	FIELD field_2318 miningPosX I
+	FIELD field_2319 miningPosY I
+	FIELD field_2320 miningPosZ I
+	FIELD field_2321 startMiningTime I
+	METHOD <init> (Lnet/minecraft/class_73;)V
+		ARG 1 world
+	METHOD method_1828 update ()V
+	METHOD method_1829 continueMining (III)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+	METHOD method_1830 onBlockBreakingAction (IIII)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 direction
+	METHOD method_1831 iteractItem (Lnet/minecraft/class_54;Lnet/minecraft/class_18;Lnet/minecraft/class_31;)Z
+		ARG 1 player
+		ARG 2 world
+		ARG 3 stack
+	METHOD method_1832 interactBlock (Lnet/minecraft/class_54;Lnet/minecraft/class_18;Lnet/minecraft/class_31;IIII)Z
+		ARG 1 player
+		ARG 2 world
+		ARG 3 stack
+		ARG 4 x
+		ARG 5 y
+		ARG 6 z
+		ARG 7 side
+	METHOD method_1833 finishMining (III)Z
+		COMMENT @return if block successfully mined
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+	METHOD method_1834 tryBreakBlock (III)Z
+		COMMENT @return if block successfully broke
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z


### PR DESCRIPTION
Directly named and mapped to https://maven.fabricmc.net/docs/yarn-1.21.1+build.3/net/minecraft/server/network/ServerPlayerInteractionManager.html
Methods, variables, and their functions are identical.
Everything in this PR should match the yarn names including the slight adjustment to ServerPlayerEntity.