### PR TITLE
Map ServerPlayerEntity

### DIFF
--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -55,10 +55,13 @@ CLASS net/minecraft/class_54 net/minecraft/entity/player/PlayerEntity
 		ARG 2 count
 	METHOD method_492 respawn ()V
 	METHOD method_493 closeHandledScreen ()V
+	METHOD method_494 spawn ()V
 	METHOD method_495 trySleep (III)Lnet/minecraft/class_141;
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
+	METHOD method_496 onCursorStackChanged (Lnet/minecraft/class_31;)V
+		ARG 1 stack
 	METHOD method_497 wakeUp (ZZZ)V
 		ARG 1 resetSleepTimer
 		ARG 2 updateSleepingPlayers

--- a/mappings/net/minecraft/entity/player/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/ServerPlayerEntity.mapping
@@ -1,17 +1,42 @@
 CLASS net/minecraft/class_69 net/minecraft/entity/player/ServerPlayerEntity
 	FIELD field_255 networkHandler Lnet/minecraft/class_11;
 	FIELD field_256 server Lnet/minecraft/server/MinecraftServer;
+	FIELD field_257 lastHealthScore I
+	FIELD field_258 joinInvulnerabilityTicks I
+	FIELD field_259 equipment [Lnet/minecraft/class_31;
+	FIELD field_260 screenHandlerSyncId I
 	FIELD field_261 interactionManager Lnet/minecraft/class_70;
+	FIELD field_262 lastX D
+	FIELD field_263 lastZ D
+	FIELD field_264 pendingChunkUpdates Ljava/util/List;
+	FIELD field_265 activeChunks Ljava/util/Set;
+	FIELD field_266 skipPacketSlotUpdates Z
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_18;Ljava/lang/String;Lnet/minecraft/class_70;)V
 		ARG 1 server
 		ARG 2 world
 		ARG 3 name
 		ARG 4 interactionManager
-	METHOD method_310 (FFZZFF)V
+	METHOD method_307 onHandledScreenClosed ()V
+	METHOD method_308 onDisconnect ()V
+	METHOD method_309 markHealthDirty ()V
+	METHOD method_310 updateInput (FFZZFF)V
+		ARG 1 forwardSpeed
+		ARG 2 sidewaysSpeed
 		ARG 3 jumping
 		ARG 4 sneaking
 		ARG 5 pitch
 		ARG 6 yaw
+	METHOD method_311 onContentsUpdate (Lnet/minecraft/class_71;)V
+		ARG 1 screenHandler
+	METHOD method_312 updateBlockEntity (Lnet/minecraft/class_55;)V
+		ARG 1 blockentity
+	METHOD method_313 playerTick (Z)V
+		ARG 1 shouldSendChunkUpdates
+	METHOD method_314 incrementScreenHandlerSyncId ()V
+	METHOD method_315 handleFall (DZ)V
+		ARG 1 heightDifference
+		ARG 3 onGround
 	METHOD method_316 getEquipment (I)Lnet/minecraft/class_31;
 		ARG 1 slot
+	METHOD method_317 initScreenHandler ()V
 	METHOD method_319 updateCursorStack ()V


### PR DESCRIPTION
Additions to PlayerEntity:
I tested method_494 to be spawn (specifically spawn animation but it's kind of irrelevant because there is no spawn animation) but it is called from an animation packet, but its also client-side only as evident by @Environment tag and also being implemented in only OtherPlayerEntity and ClientPlayerEntity.

onCursorStackChanged (method_496) nothing is used, but that is its functionality, so I gave it an apt name, and it was removed in later versions (1.21)
![image](https://github.com/user-attachments/assets/a1824862-c7ff-4d1e-8b2f-21f9ee47bed2)

Additions to ServerPlayerEntity:
not going to mention the ones that are yarn matching see https://maven.fabricmc.net/docs/yarn-1.21.1+build.3/net/minecraft/server/network/ServerPlayerEntity.html
lastX, lastZ, pendingChunkUpdates, and activeChunks all have to do with class_166 and the handling of chunk updates, this will make more sense in my other PR that tackles that stuff, but it was largely replaced post 1.9

skipPacketSlotUpdates is not in yarn, self-explanatory though.

initScreenHandler is not yarn, but its function is obvious

others are mostly yarny? Definitely feel free to give input though, and I'll probably change it but I definitely mulled over this one a good amount.

