### PR TITLE
Map NaturalSpawner & Minor Fix

### DIFF
--- a/mappings/net/minecraft/entity/SpawnGroup.mapping
+++ b/mappings/net/minecraft/entity/SpawnGroup.mapping
@@ -15,3 +15,4 @@ CLASS net/minecraft/class_238 net/minecraft/entity/SpawnGroup
 	METHOD method_854 getCapacity ()I
 	METHOD method_855 getSpawnMaterial ()Lnet/minecraft/class_15;
 	METHOD method_856 isPeaceful ()Z
+	METHOD values values ()[Lnet/minecraft/class_238;

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -43,7 +43,7 @@ CLASS net/minecraft/class_54 net/minecraft/entity/player/PlayerEntity
 		ARG 3 z
 	METHOD method_485 openDispenserScreen (Lnet/minecraft/class_137;)V
 		ARG 1 dispenser
-	METHOD method_486 openDoubleChestScreen (Lnet/minecraft/class_134;)V
+	METHOD method_486 openChestScreen (Lnet/minecraft/class_134;)V
 		ARG 1 inventory
 	METHOD method_487 openFurnaceScreen (Lnet/minecraft/class_138;)V
 		ARG 1 furnace

--- a/mappings/net/minecraft/world/NaturalSpawner.mapping
+++ b/mappings/net/minecraft/world/NaturalSpawner.mapping
@@ -23,7 +23,7 @@ CLASS net/minecraft/class_567 net/minecraft/world/NaturalSpawner
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z
-	METHOD method_1872 spawnMonstersAndWakePlayers (Lnet/minecraft/class_127;Lnet/minecraft/class_18;FFF)V
+	METHOD method_1872 postSpawnEntity (Lnet/minecraft/class_127;Lnet/minecraft/class_18;FFF)V
 		ARG 0 entity
 		ARG 1 world
 		ARG 2 x

--- a/mappings/net/minecraft/world/NaturalSpawner.mapping
+++ b/mappings/net/minecraft/world/NaturalSpawner.mapping
@@ -1,0 +1,31 @@
+CLASS net/minecraft/class_567 net/minecraft/world/NaturalSpawner
+	FIELD field_2408 MONSTER_TYPE [Ljava/lang/Class;
+		COMMENT Class is of any extends Monster
+	FIELD field_2409 mobSpawningChunks Ljava/util/Set;
+		COMMENT Set of ChunkPos.
+		COMMENT This set keeps track of chunks that allow mob spawning. Mob spawning can occur within
+		COMMENT a 15x15 grid of chunks around players. The ring of chunks around that are lazy chunks,
+		COMMENT which do not allow mob spawning, but to contribute to the mob cap.
+	METHOD method_1868 getRandomPosInChunk (Lnet/minecraft/class_18;II)Lnet/minecraft/class_339;
+		ARG 0 world
+		ARG 1 chunkX
+		ARG 2 chunkZ
+	METHOD method_1869 spawnMonstersAndWakePlayers (Lnet/minecraft/class_18;Ljava/util/List;)Z
+		ARG 0 world
+		ARG 1 players
+	METHOD method_1870 tick (Lnet/minecraft/class_18;ZZ)I
+		ARG 0 world
+		ARG 1 spawnAnimals
+		ARG 2 spawnMonsters
+	METHOD method_1871 isValidSpawnPos (Lnet/minecraft/class_238;Lnet/minecraft/class_18;III)Z
+		ARG 0 spawnGroup
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1872 spawnMonstersAndWakePlayers (Lnet/minecraft/class_127;Lnet/minecraft/class_18;FFF)V
+		ARG 0 entity
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/paulscode/sound/codecs/CodecJOrbis.mapping
+++ b/mappings/paulscode/sound/codecs/CodecJOrbis.mapping
@@ -1,0 +1,4 @@
+CLASS paulscode/sound/codecs/CodecJOrbis
+	FIELD urlConnection urlConnection Ljava/net/URLConnection;
+	FIELD url url Ljava/net/URL;
+	METHOD openInputStream openInputStream ()Ljava/io/InputStream;

--- a/mappings/paulscode/sound/codecs/CodecMus.mapping
+++ b/mappings/paulscode/sound/codecs/CodecMus.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_309 paulscode/sound/codecs/CodecMus
+	CLASS class_310 MusInputStream
+		FIELD field_1195 buffer [B
+		FIELD field_1197 hash I
+		FIELD field_1198 inputStream Ljava/io/InputStream;
+		METHOD <init> (Lnet/minecraft/class_309;Ljava/net/URL;Ljava/io/InputStream;)V
+			ARG 2 fileURL
+			ARG 3 inputStream
+		METHOD read read ()I
+		METHOD read read ([BII)I


### PR DESCRIPTION
NaturalSpawner deals with spawning monsters around all Players in nearby chunks, and it is now mapped.
Additionally in PlayerEntity, openDoubleChestScreen is changed to openChestScreen because it does both double chests and chests.